### PR TITLE
remove query string since Ghost 0.4

### DIFF
--- a/buster/buster.py
+++ b/buster/buster.py
@@ -44,8 +44,16 @@ def main():
                    "--directory-prefix {1} \\"  # download contents to static/ folder
                    "--no-host-directories \\"   # don't create domain named folder
                    "{0}").format(arguments['--domain'], static_path)
-
         os.system(command)
+
+        # remove query string since Ghost 0.4
+        file_regex = re.compile(r'.*?(\?.*)')
+        for root, dirs, filenames in os.walk(static_path):
+            for filename in filenames:
+              if file_regex.match(filename):
+                  newname = re.sub(r'\?.*', '', filename)
+                  print "Rename", filename, "=>", newname
+                  os.rename(os.path.join(root, filename), os.path.join(root, newname)) 
 
     elif arguments['preview']:
         os.chdir(static_path)

--- a/buster/buster.py
+++ b/buster/buster.py
@@ -2,7 +2,7 @@
 
 Usage:
   buster.py setup [--gh-repo=<repo-url>] [--dir=<path>]
-  buster.py generate [--domain=<local-address>] [--dir=<path>]
+  buster.py generate [--domain=<local-address>] [--dir=<path>] [--ghost_path=<path>]
   buster.py preview [--dir=<path>]
   buster.py deploy [--dir=<path>]
   buster.py add-domain <domain-name> [--dir=<path>]
@@ -15,6 +15,7 @@ Options:
   --dir=<path>              Absolute path of directory to store static pages.
   --domain=<local-address>  Address of local ghost installation [default: local.tryghost.org].
   --gh-repo=<repo-url>      URL of your gh-pages repository.
+  --ghost_path=<path>              Absolute path of directory to Ghost.
 """
 
 import os
@@ -54,6 +55,13 @@ def main():
                   newname = re.sub(r'\?.*', '', filename)
                   print "Rename", filename, "=>", newname
                   os.rename(os.path.join(root, filename), os.path.join(root, newname)) 
+
+        # copy images in GHOST_PATH/content/images folder into static folder
+        if arguments['--ghost_path'] is not None:
+            ghost_path = arguments['--ghost_path']
+        else:
+            ghost_path = os.path.join(os.getcwd(), 'ghost')
+        shutil.copytree(os.path.join(ghost_path, 'content/images'), os.path.join(static_path, 'content/images'), False)
 
     elif arguments['preview']:
         os.chdir(static_path)

--- a/buster/buster.py
+++ b/buster/buster.py
@@ -61,7 +61,7 @@ def main():
             ghost_path = arguments['--ghost_path']
         else:
             ghost_path = os.path.join(os.getcwd(), 'ghost')
-        shutil.copytree(os.path.join(ghost_path, 'content/images'), os.path.join(static_path, 'content/images'), False)
+        copyFiles(os.path.join(ghost_path, 'content/images'), os.path.join(static_path, 'content/images'))
 
     elif arguments['preview']:
         os.chdir(static_path)
@@ -133,6 +133,19 @@ def main():
 
     else:
         print __doc__
+
+def copyFiles(sourceDir, targetDir):
+    for f in os.listdir(sourceDir):
+        sourceF = os.path.join(sourceDir, f)
+        targetF = os.path.join(targetDir, f)
+        if os.path.isfile(sourceF):
+            if not os.path.exists(targetDir):
+                os.makedirs(targetDir)               
+            if not os.path.exists(targetF) or (os.path.exists(targetF) and (os.path.getsize(targetF) != os.path.getsize(sourceF))):
+                open(targetF, "wb").write(open(sourceF, "rb").read())
+           
+        if os.path.isdir(sourceF):   
+            copyFiles(sourceF, targetF)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
When I use Ghost 0.4 to create static pages, I have some issue to load css and js files. I notice that Ghost 0.4 add some query string after css and js links. So, after generating we have to rename these files.
