### PR TITLE
Integrate buster and docker container engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu
+
+RUN apt-get update
+RUN apt-get install -y python-pip wget git build-essential python-dev
+
+# GitPython needs this environment variable when run
+# inside a container
+ENV USER hamiltont
+
+ADD . /buster
+RUN cd /buster && python setup.py install
+
+ENTRYPOINT ["buster"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,12 @@ RUN apt-get install -y python-pip wget git build-essential python-dev
 
 # GitPython needs this environment variable when run
 # inside a container
-ENV USER hamiltont
+ENV USER root
 
 ADD . /buster
 RUN cd /buster && python setup.py install
 
-ENTRYPOINT ["buster"]
+# Remove about 80MB of extra stuff ;-)
+RUN apt-get remove -y build-essential python-dev
+RUN apt-get autoremove -y
+

--- a/README.rst
+++ b/README.rst
@@ -92,8 +92,6 @@ Run via Docker
 
 `Docker <https://www.docker.io/>`__ is an easy way to run Buster in an isolated environment. 
 
-First, we download the site. Then we generate and deploy. 
-
 Substitute a `Github access token <https://help.github.com/articles/creating-an-access-token-for-command-line-use>`__
 for ${TOKEN}, your **https** stype repository URL for ${REPO}, and your website for 
 ${SITE}
@@ -101,13 +99,12 @@ ${SITE}
     $ TOKEN=q2e42be10665b0307069a56bc389f342a797d34e
     $ REPO=github.com/you/your_repo.git
     $ SITE=my_ghost_blog.com
-    $ SETUP=$(sudo docker run -d axitkhurana/buster setup-clone --gh-repo=https://${TOKEN}@${REPO})
-    $ GEN=$(sudo docker run -d $SETUP generate --domain=${SITE})
-    $ sudo docker run $GEN deploy
+    $ sudo docker run axitkhurana/buster /bin/sh -c "buster setup-clone --gh-repo=https://${TOKEN}@${REPO} && \
+        buster generate --domain=${SITE} && \
+        buster deploy"
 
 If you only ever use Buster, then you only have to run setup-clone once. After 
-that you can store and reuse the SETUP container. Use docker logs $SETUP to see 
-the ouput of the containers
+that you could store and reuse the container for generate & deploy. 
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,28 @@ Inspired by THE GhostBusters.
 
    Ghost Buster Movie
 
+Run via Docker
+--------------
+
+`Docker <https://www.docker.io/>`__ is an easy way to run Buster in an isolated environment. 
+
+First, we download the site. Then we generate and deploy. 
+
+Substitute a `Github access token <https://help.github.com/articles/creating-an-access-token-for-command-line-use>`__
+for ${TOKEN}, your **https** stype repository URL for ${REPO}, and your website for 
+${SITE}
+
+    $ TOKEN=q2e42be10665b0307069a56bc389f342a797d34e
+    $ REPO=github.com/you/your_repo.git
+    $ SITE=my_ghost_blog.com
+    $ SETUP=$(sudo docker run -d axitkhurana/buster setup-clone --gh-repo=https://${TOKEN}@${REPO})
+    $ GEN=$(sudo docker run -d $SETUP generate --domain=${SITE})
+    $ sudo docker run $GEN deploy
+
+If you only ever use Buster, then you only have to run setup-clone once. After 
+that you can store and reuse the SETUP container. Use docker logs $SETUP to see 
+the ouput of the containers
+
 Contributing
 ------------
 

--- a/buster/buster.py
+++ b/buster/buster.py
@@ -2,6 +2,7 @@
 
 Usage:
   buster.py setup [--gh-repo=<repo-url>] [--dir=<path>]
+  buster.py setup-clone [--gh-repo=<repo-url>] [--dir=<path>]
   buster.py generate [--domain=<local-address>] [--dir=<path>]
   buster.py preview [--dir=<path>]
   buster.py deploy [--dir=<path>]
@@ -101,6 +102,34 @@ def main():
 
         print "All set! You can generate and deploy now."
 
+    elif arguments['setup-clone']:
+        if arguments['--gh-repo']:
+            repo_url = arguments['--gh-repo']
+        else:
+            repo_url = raw_input("Enter the Github repository URL:\n").strip()
+
+        # Create a fresh new static files directory
+        if os.path.isdir(static_path):
+            confirm = raw_input("This will destroy everything inside static/."
+                                " Are you sure you want to continue? (y/N)").strip()
+            if confirm != 'y' and confirm != 'Y':
+                sys.exit(0)
+            shutil.rmtree(static_path)
+
+        # User/Organization page -> master branch
+        # Project page -> gh-pages branch
+        branch = 'gh-pages'
+        regex = re.compile(".*[\w-]+\.github\.(?:io|com).*")
+        if regex.match(repo_url):
+            branch = 'master'
+
+        # Prepare git repository
+        repo = Repo.clone_from(repo_url, static_path)
+        git = repo.git
+
+        # TODO please check if gh-pages vs master works properly here        
+
+        print "All set! You can generate and deploy now."
     elif arguments['deploy']:
         repo = Repo(static_path)
         repo.git.add('.')


### PR DESCRIPTION
Heyo, 

I wanted a one-off command that could install+run buster. This does that using docker, which acts as a lightweight virtual environment. It 1) installs buster 2) downloads the site 3) runs buster and 4) deploys. Github tokens are used to avoid people accidentally putting their private key online. There is enough documentation added to explain how to run this while avoiding imposing on people not interested. 

The primary advantage is anyone with docker installed can now use buster on any Ghost site with this one command, without changing their system at all. 

I have pushed a docker image to hamiltont/buster, but the docs I added reference axitkhurana/buster. You can easily register on index.docker.io and point them to your buster repository to have a "trusted build" performed (e.g. they clone your repo and build the container using the Dockerfile). 

I've also added a setup-clone run mode that will perform setup using `git clone` instead of `git init`. This may be better if done as an option of setup (e.g. `buster setup --clone` instead of `buster setup-clone`).
There is one TODO left in the setup-clone method, I'm not very familiar with GH pages so I may have misunderstood how to properly treat master/gh-pages e.g. a checkout may be needed here. 
