### PR TITLE
Added a fix for Windows users.

### DIFF
--- a/buster/_version.py
+++ b/buster/_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 1, 2)
+__version_info__ = (0, 1, 3)
 __version__ = '.'.join(map(str, __version_info__))

--- a/buster/_version.py
+++ b/buster/_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 1, 3)
+__version_info__ = (0, 1, 2)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
I fixed a glitch with calling wget when running on a windows platform, and added the option to remove version info from asset file names since it was causing firefox and chrome to not load ".css" and ".js" files.
