### PR TITLE
Pull RSS feed pages for tags and authors

### DIFF
--- a/buster/buster.py
+++ b/buster/buster.py
@@ -49,6 +49,20 @@ def main():
                    "{0}").format(arguments['--domain'], static_path)
         os.system(command)
 
+        for dir in os.listdir(static_path + "/tag"):
+            os.mkdir(static_path + "/tag/" + dir + "/rss")
+            command = ("wget "
+                       "--output-document=" + static_path + "/tag/" + dir + "/rss/index.html "
+                       "{0}/tag/" + dir + "/rss").format(arguments['--domain'])
+            os.system(command)
+        for dir in os.listdir(static_path + "/author"):
+            os.mkdir(static_path + "/author/" + dir + "/rss")
+            command = ("wget "
+                       "--output-document=" + static_path + "/author/" + dir + "/rss/index.html "
+                       "{0}/tag/" + dir + "/rss").format(arguments['--domain'])
+            os.system(command)
+
+
         # remove query string since Ghost 0.4
         file_regex = re.compile(r'.*?(\?.*)')
         for root, dirs, filenames in os.walk(static_path):

--- a/buster/buster.py
+++ b/buster/buster.py
@@ -49,18 +49,17 @@ def main():
                    "{0}").format(arguments['--domain'], static_path)
         os.system(command)
 
-        for dir in os.listdir(static_path + "/tag"):
-            os.mkdir(static_path + "/tag/" + dir + "/rss")
-            command = ("wget "
-                       "--output-document=" + static_path + "/tag/" + dir + "/rss/index.html "
-                       "{0}/tag/" + dir + "/rss").format(arguments['--domain'])
-            os.system(command)
-        for dir in os.listdir(static_path + "/author"):
-            os.mkdir(static_path + "/author/" + dir + "/rss")
-            command = ("wget "
-                       "--output-document=" + static_path + "/author/" + dir + "/rss/index.html "
-                       "{0}/tag/" + dir + "/rss").format(arguments['--domain'])
-            os.system(command)
+        def pullRss(path):
+            for feed in os.listdir(static_path + "/" + path):
+                rsspath = "/" + path + "/" + feed + "/rss"
+                rssdir = static_path + rsspath
+                os.mkdir(rssdir)
+                command = ("wget "
+                       "--output-document=" + rssdir + "/index.html "
+                       "{0}" + rsspath).format(arguments['--domain'])
+                os.system(command)
+        pullRss("tag")
+        pullRss("author")
 
 
         # remove query string since Ghost 0.4

--- a/buster/buster.py
+++ b/buster/buster.py
@@ -51,7 +51,7 @@ def main():
 
         def pullRss(path):
             for feed in os.listdir(static_path + "/" + path):
-                rsspath = "/" + path + "/" + feed + "/rss"
+                rsspath = "/" + path + "/" + feed + "/rss/"
                 rssdir = static_path + rsspath
                 os.mkdir(rssdir)
                 command = ("wget "


### PR DESCRIPTION
Ghost supports RSS feeds at the tag and author level.  For completeness, this change pulls down the RSS feed for each author and each tag that has content.
